### PR TITLE
Scroll api support for reading large datasets in batches

### DIFF
--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -26,8 +26,34 @@ const $elastic = function(){
     };
 
     this.search = (obj) => {
+        
         return new $promise((resolve, reject) => {
-            self.client.search(obj).then(resolve, (err) => reject(self.$$formatError(err)));
+            
+            if(typeof obj.scroll_id !== 'undefined') {
+
+                const {scroll, scroll_id} = obj;
+                
+                self.client.scroll({
+                    scroll, 
+                    scroll_id
+                }).then((res) => {
+
+                    if(res.hits.hits.length === 0) {
+                        self.client.clearScroll(res.scroll_id);
+                    }
+
+                    resolve(res);
+
+                }, (err) => reject(self.$$formatError(err)));
+
+            } else {
+
+                self.client.search(obj)
+                    .then(resolve, (err) => reject(self.$$formatError(err)));
+
+            }
+            
+        
         });
     };
 
@@ -46,7 +72,18 @@ const $elastic = function(){
             "body" : {}
         };
 
+        //set scroll timeout
+        if(obj._elasticScrollTimeout && obj._elasticScrollTimeout.length > 0) {
+            objSearch.scroll = obj._elasticScrollTimeout;
+        }
+
+        //set scroll id
+        if(obj._elasticScrollSessionId && obj._elasticScrollSessionId.length > 0) {
+            objSearch.scroll_id = obj._elasticScrollSessionId;
+        }
+
         if(obj.sorts.length>0){
+            
             objSearch.body.sort=[];
 
             obj.sorts.forEach((sort) => {

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -29,6 +29,7 @@ const $elastic = function(){
         
         return new $promise((resolve, reject) => {
             
+            //if search object has scroll id set that means we are reading results via Scroll API
             if(typeof obj.scroll_id !== 'undefined') {
 
                 const {scroll, scroll_id} = obj;
@@ -38,6 +39,7 @@ const $elastic = function(){
                     scroll_id
                 }).then((res) => {
 
+                    //manually release scroll session when there are no more results to read
                     if(res.hits.hits.length === 0) {
                         self.client.clearScroll(res.scroll_id);
                     }
@@ -72,12 +74,12 @@ const $elastic = function(){
             "body" : {}
         };
 
-        //set scroll timeout
+        //Scroll API: set scroll timeout
         if(obj._elasticScrollTimeout && obj._elasticScrollTimeout.length > 0) {
             objSearch.scroll = obj._elasticScrollTimeout;
         }
 
-        //set scroll id
+        //Scroll API: set scroll id
         if(obj._elasticScrollSessionId && obj._elasticScrollSessionId.length > 0) {
             objSearch.scroll_id = obj._elasticScrollSessionId;
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -38,6 +38,8 @@ module.exports = function restfulQuery(tables, req, res, errorHandler){
         _db: "", //PRIVATE - client db
         _filters: {}, //PRIVATE - search params
         _elastic: undefined, //PRIVATE - search params
+        _elasticScrollTimeout: undefined, //PRIVATE - timeout for scroll api reads
+        _elasticScrollSessionId: undefined, //PRIVATE - holds _scroll_id for active scroll session
         _joins: [], //PRIVATE - joins other tables to main table
         _section: "", //PRIVATE - current section
         _sections: {}, //PRIVATE - available sub sections
@@ -197,6 +199,14 @@ module.exports = function restfulQuery(tables, req, res, errorHandler){
             obj._elastic = !!self.$getTableIsElastic(objParams);
         }else{
             obj._elastic = !!objParams._elastic;
+        }
+
+        if(typeof objParams._elasticScrollTimeout !== 'undefined'){
+            obj._elasticScrollTimeout = objParams._elasticScrollTimeout;
+        }
+
+        if(typeof objParams._elasticScrollSessionId !== 'undefined'){
+            obj._elasticScrollSessionId = objParams._elasticScrollSessionId;
         }
 
         //set namespace
@@ -495,6 +505,16 @@ module.exports = function restfulQuery(tables, req, res, errorHandler){
         //elastic
         if(typeof p._elastic !== 'undefined'){
             obj._elastic = !!p._elastic;
+        }
+
+        //elastic scroll mode timeout
+        if(typeof p._elasticScrollTimeout !== 'undefined'){
+            obj._elasticScrollTimeout = p._elasticScrollTimeout;
+        }
+
+        //elastic scroll mode id
+        if(typeof p._elasticScrollSessionId !== 'undefined'){
+            obj._elasticScrollSessionId = p._elasticScrollSessionId;
         }
 
         //namespace


### PR DESCRIPTION
## Description
Relies on `obj.scroll_id` to figure out whether to issue a regular index search request or read from the active scroll session initiated by a previous search request.

## Motivation & Context
* https://github.com/envistaInteractive/node-cep-services/pull/187
* elastic/elasticsearch#18124

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
 
